### PR TITLE
Termination protections: defense-in-depth for GPU instance cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ Thumbs.db
 # Claude Code
 .claude/
 
+# Git worktrees
+.worktrees/
+
 # Go
 vendor/
 go.work

--- a/docs/plans/2026-02-23-termination-protections-design.md
+++ b/docs/plans/2026-02-23-termination-protections-design.md
@@ -1,0 +1,108 @@
+# Termination Protections — Defense-in-Depth Design
+
+**Date:** 2026-02-23
+**Status:** Approved
+**Trigger:** TensorDock deployment ran until account balance went negative due to failed instance cleanup.
+
+## Problem Statement
+
+A TensorDock GPU instance was not destroyed when expected, accumulating charges until the account balance went negative. Investigation revealed 5 gaps in the termination chain that affect all providers (TensorDock, Vast.ai, Blue Lobster).
+
+## Root Cause Analysis
+
+| Gap | Description | Severity |
+|-----|-------------|----------|
+| G1: Stuck-then-failed sessions leak instances | `destroyWithVerification` fails after 10 retries → session enters `stopping` → lifecycle marks it `failed` → provider instance never retried for destruction | Critical |
+| G2: TensorDock tags are name-only | Only instance name used for identification (`shopper-{sessionID}`). No `ShopperExpiresAt` or `ShopperDeploymentID` transmitted. Unknown-named instances invisible to cleanup. | High |
+| G3: No re-destroy for failed sessions | Once marked `failed`, no periodic mechanism re-attempts destruction. Failed session with live provider instance sits forever. | Critical |
+| G4: No pre-provision balance check | No provider billing API integration. Instances provisioned even when account is nearly empty. | Medium |
+| G5: Shutdown timeout abandons instances | If graceful shutdown exceeds 60s timeout, remaining destroys are abandoned. Instances keep running. | Medium |
+
+### Key Code Paths
+
+- `GetExpiredSessions()` only queries `StatusRunning` — ignoring `StatusStopping` and `StatusFailed`
+- `checkStuckSessions()` marks stuck-in-stopping sessions as `failed` but does NOT re-attempt destroy
+- `GetActiveSessionsByProvider()` excludes `StatusFailed` — so reconciler treats the live instance as an orphan (good), but only if `ListAllInstances()` returns it (depends on naming)
+- TensorDock `instancesToProviderInstances()` silently drops instances without `shopper-` prefix
+
+## Design
+
+### 1. Failed-Destroy Watchdog (fixes G1, G3)
+
+New method `checkFailedDestroys(ctx)` in lifecycle manager, called in the existing `run()` loop alongside other periodic checks.
+
+**Behavior:**
+- Query sessions with `status=failed AND provider_id != ''`
+- For each, attempt `prov.DestroyInstance(ctx, session.ProviderID)`
+- On success: update session to `stopped` status, log audit event
+- On failure: log at ERROR level, leave session as `failed` for next tick
+- Runs every lifecycle tick (1 minute)
+
+**Storage:** Add `GetFailedSessionsWithInstances(ctx) ([]*Session, error)` — returns `status=failed, provider_id != ''`.
+
+### 2. Shutdown Fire-and-Forget (fixes G5)
+
+After shutdown timeout fires, iterate any remaining unfinished sessions and call `prov.DestroyInstance()` once each without verification. This is a last-chance kill.
+
+**Changes:**
+- After `wg.Wait()` timeout in `GracefulShutdown`: fire one `DestroyInstance` call per remaining session
+- Log each at ERROR with provider name and instance ID
+
+### 3. Increase Shutdown Timeout (fixes G5)
+
+Change `DefaultShutdownTimeout` from 60s to 120s. A single stubborn destroy with 10 retries at exponential backoff takes ~55s. Multiple parallel destroys need more headroom.
+
+### 4. BalanceProvider Interface — Warn Only (fixes G4)
+
+New optional interface:
+
+```go
+type BalanceProvider interface {
+    GetAccountBalance(ctx context.Context) (*AccountBalance, error)
+}
+
+type AccountBalance struct {
+    Balance  float64
+    Currency string
+}
+```
+
+**Provisioner behavior:** Before creating an instance, check if provider implements `BalanceProvider`. If so, check balance. If below configurable threshold (default $5.00), log a WARNING but allow provisioning to proceed.
+
+**Provider implementations:**
+- Vast.ai: Implement using `/users/current/` endpoint (returns balance)
+- TensorDock: Return `ErrNotSupported` (billing API under development)
+- Blue Lobster: Return `ErrNotSupported`
+
+### 5. Log Unknown TensorDock Instances (fixes G2)
+
+In `instancesToProviderInstances()`, when an instance name doesn't match `shopper-*` prefix, log at WARN level with instance name and ID. Provides visibility into potentially leaked instances.
+
+### 6. Reduce Reconcile Interval (fixes G1, G2, G3)
+
+Change `DefaultReconcileInterval` from 5 minutes to 2 minutes. Faster orphan detection reduces the window for uncontrolled charges.
+
+### 7. Startup Sweep for Failed Sessions (fixes G1, G3)
+
+Extend `RecoverStuckSessions` to also check failed sessions with non-empty `ProviderID`. On startup, attempt to destroy any lingering provider instances from previously failed sessions.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `internal/service/lifecycle/manager.go` | Add `checkFailedDestroys()` method, wire into `run()` loop |
+| `internal/service/lifecycle/startup.go` | Fire-and-forget destroys after timeout, increase default timeout |
+| `internal/service/lifecycle/reconciler.go` | Reduce interval to 2min, extend stuck session recovery |
+| `internal/storage/sessions.go` | Add `GetFailedSessionsWithInstances()` query |
+| `internal/provider/interface.go` | Add `BalanceProvider` interface and `AccountBalance` type |
+| `internal/provider/vastai/client.go` | Implement `GetAccountBalance()` |
+| `internal/provider/tensordock/client.go` | Log unknown instances in `instancesToProviderInstances()` |
+| `internal/service/provisioner/service.go` | Add pre-provision balance warning |
+
+## Testing Strategy
+
+- Unit tests for `checkFailedDestroys()` with mock store and provider
+- Unit tests for fire-and-forget shutdown path
+- Unit test for `GetFailedSessionsWithInstances()` query
+- Unit test for `BalanceProvider` check in provisioner (both supported and unsupported)
+- Integration test: create session, force-fail destroy, verify watchdog recovers it

--- a/docs/plans/2026-02-23-termination-protections-impl.md
+++ b/docs/plans/2026-02-23-termination-protections-impl.md
@@ -1,0 +1,1064 @@
+# Termination Protections Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent GPU instances from running uncontrolled after failed destroy attempts, with defense-in-depth across all providers.
+
+**Architecture:** Add a failed-destroy watchdog to the lifecycle manager's periodic check loop, harden shutdown to fire-and-forget as a last resort, extend startup sweep to recover failed sessions, add optional balance checking via a new `BalanceProvider` interface, and improve TensorDock instance visibility. All changes are application-level within existing service boundaries.
+
+**Tech Stack:** Go, testify (assert/require), existing lifecycle/provisioner/provider packages.
+
+**Design doc:** `docs/plans/2026-02-23-termination-protections-design.md`
+
+---
+
+### Task 1: Add `GetFailedSessionsWithInstances` storage query
+
+**Files:**
+- Modify: `internal/storage/sessions.go:276-284` (add new query after `GetExpiredSessions`)
+- Test: `internal/storage/sessions_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/storage/sessions_test.go`:
+
+```go
+func TestSessionStore_GetFailedSessionsWithInstances(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create a failed session WITH a provider ID (leaked instance)
+	leaked := &models.Session{
+		ID:         "sess-leaked",
+		Provider:   "tensordock",
+		ProviderID: "td-12345",
+		Status:     models.StatusFailed,
+		Error:      "Session stuck in stopping state - manual cleanup may be required",
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		ExpiresAt:  time.Now().Add(-1 * time.Hour),
+		StoppedAt:  time.Now().Add(-30 * time.Minute),
+	}
+	require.NoError(t, store.Create(ctx, leaked))
+
+	// Create a failed session WITHOUT provider ID (never got an instance)
+	noInstance := &models.Session{
+		ID:        "sess-no-instance",
+		Provider:  "tensordock",
+		Status:    models.StatusFailed,
+		Error:     "Provisioning failed - no provider instance ID",
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+		ExpiresAt: time.Now(),
+		StoppedAt: time.Now().Add(-30 * time.Minute),
+	}
+	require.NoError(t, store.Create(ctx, noInstance))
+
+	// Create a running session (should not be returned)
+	running := &models.Session{
+		ID:         "sess-running",
+		Provider:   "vastai",
+		ProviderID: "vast-99",
+		Status:     models.StatusRunning,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(1 * time.Hour),
+	}
+	require.NoError(t, store.Create(ctx, running))
+
+	// Query
+	results, err := store.GetFailedSessionsWithInstances(ctx)
+	require.NoError(t, err)
+
+	// Should return only the leaked session
+	assert.Len(t, results, 1)
+	assert.Equal(t, "sess-leaked", results[0].ID)
+	assert.Equal(t, "td-12345", results[0].ProviderID)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/storage/ -run TestSessionStore_GetFailedSessionsWithInstances -v`
+Expected: FAIL — `GetFailedSessionsWithInstances` not defined
+
+**Step 3: Write minimal implementation**
+
+Add to `internal/storage/sessions.go` after `GetExpiredSessions` (after line 284):
+
+```go
+// GetFailedSessionsWithInstances returns failed sessions that still have a provider instance ID.
+// These are sessions where the destroy failed but the provider instance may still be running.
+func (s *SessionStore) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	return s.ListInternal(ctx, SessionFilter{
+		Statuses:          []models.SessionStatus{models.StatusFailed},
+		HasProviderID:     true,
+	})
+}
+```
+
+Also update the `SessionFilter` struct and `ListInternal` to support the `HasProviderID` filter. In the `SessionFilter` struct (around line 305), add:
+
+```go
+HasProviderID bool // If true, only return sessions with non-empty provider_id
+```
+
+In the `ListInternal` method where it builds the SQL query, add a condition:
+
+```go
+if f.HasProviderID {
+	conditions = append(conditions, "provider_id != ''")
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/storage/ -run TestSessionStore_GetFailedSessionsWithInstances -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/storage/sessions.go internal/storage/sessions_test.go
+git commit -m "feat: add GetFailedSessionsWithInstances storage query
+
+Returns failed sessions with non-empty provider IDs for the
+failed-destroy watchdog to re-attempt instance destruction."
+```
+
+---
+
+### Task 2: Add `checkFailedDestroys` to lifecycle manager
+
+**Files:**
+- Modify: `internal/service/lifecycle/manager.go:34-41` (add to `SessionStore` interface)
+- Modify: `internal/service/lifecycle/manager.go:96-106` (add metric)
+- Modify: `internal/service/lifecycle/manager.go:277-288` (add call in `runChecks`)
+- Modify: `internal/service/lifecycle/manager.go:531-558` (add new method after `destroySession`)
+- Test: `internal/service/lifecycle/manager_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/service/lifecycle/manager_test.go`:
+
+```go
+func TestManager_CheckFailedDestroys(t *testing.T) {
+	store := newMockSessionStore()
+	destroyer := &mockDestroyer{}
+
+	// Add a failed session with a provider ID (leaked instance)
+	store.add(&models.Session{
+		ID:         "sess-leaked",
+		Provider:   "tensordock",
+		ProviderID: "td-12345",
+		Status:     models.StatusFailed,
+		Error:      "Session stuck in stopping state - manual cleanup may be required",
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+	})
+
+	// Add a failed session WITHOUT provider ID (should be skipped)
+	store.add(&models.Session{
+		ID:       "sess-clean-fail",
+		Provider: "vastai",
+		Status:   models.StatusFailed,
+		Error:    "Provisioning failed - no provider instance ID",
+	})
+
+	m := New(store, destroyer,
+		WithCheckInterval(100*time.Millisecond),
+		WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, m.Start(ctx))
+	defer m.Stop()
+
+	// Wait for at least one check cycle
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify destroy was called for the leaked session
+	assert.Equal(t, 1, destroyer.destroyCount())
+	assert.Contains(t, destroyer.destroyedIDs(), "sess-leaked")
+
+	// Verify the leaked session was updated to stopped
+	store.mu.RLock()
+	leaked := store.sessions["sess-leaked"]
+	store.mu.RUnlock()
+	assert.Equal(t, models.StatusStopped, leaked.Status)
+}
+
+func TestManager_CheckFailedDestroys_DestroyFails(t *testing.T) {
+	store := newMockSessionStore()
+	destroyer := &mockDestroyer{
+		err: errors.New("provider API error"),
+	}
+
+	store.add(&models.Session{
+		ID:         "sess-stubborn",
+		Provider:   "tensordock",
+		ProviderID: "td-999",
+		Status:     models.StatusFailed,
+		Error:      "Session stuck in stopping state",
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+	})
+
+	m := New(store, destroyer,
+		WithCheckInterval(100*time.Millisecond),
+		WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, m.Start(ctx))
+	defer m.Stop()
+
+	time.Sleep(300 * time.Millisecond)
+
+	// Destroy was attempted
+	assert.GreaterOrEqual(t, destroyer.destroyCount(), 1)
+
+	// Session should still be failed (not updated to stopped)
+	store.mu.RLock()
+	sess := store.sessions["sess-stubborn"]
+	store.mu.RUnlock()
+	assert.Equal(t, models.StatusFailed, sess.Status)
+}
+```
+
+You'll also need to update the mock store to implement `GetFailedSessionsWithInstances`:
+
+```go
+func (m *mockSessionStore) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*models.Session
+	for _, s := range m.sessions {
+		if s.Status == models.StatusFailed && s.ProviderID != "" {
+			copy := *s
+			result = append(result, &copy)
+		}
+	}
+	return result, nil
+}
+```
+
+And update the `mockDestroyer` to track destroyed session IDs:
+
+```go
+type mockDestroyer struct {
+	mu          sync.Mutex
+	err         error
+	callCount   int
+	destroyedBy []string
+}
+
+func (m *mockDestroyer) DestroySession(ctx context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	m.destroyedBy = append(m.destroyedBy, sessionID)
+	return m.err
+}
+
+func (m *mockDestroyer) destroyCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func (m *mockDestroyer) destroyedIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.destroyedBy
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/service/lifecycle/ -run TestManager_CheckFailedDestroys -v`
+Expected: FAIL — `GetFailedSessionsWithInstances` not in interface / `checkFailedDestroys` not defined
+
+**Step 3: Write implementation**
+
+1. Add to the `SessionStore` interface (line ~38):
+```go
+GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error)
+```
+
+2. Add metric field to `Metrics` struct (after line 103):
+```go
+FailedDestroysRecovered int64
+```
+
+3. Add `checkFailedDestroys` call in `runChecks` (line ~288, after `checkStuckSessions`):
+```go
+m.checkFailedDestroys(ctx)
+```
+
+4. Add the new method after `destroySession` (after line ~558):
+```go
+// checkFailedDestroys re-attempts destruction for sessions that failed to destroy.
+// These are sessions marked as "failed" that still have a provider instance ID,
+// meaning the provider instance may still be running and accumulating charges.
+func (m *Manager) checkFailedDestroys(ctx context.Context) {
+	sessions, err := m.store.GetFailedSessionsWithInstances(ctx)
+	if err != nil {
+		m.logger.Error("failed to get failed sessions for re-destroy",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	for _, session := range sessions {
+		m.logger.Info("re-attempting destroy for failed session",
+			slog.String("session_id", session.ID),
+			slog.String("provider", session.Provider),
+			slog.String("provider_id", session.ProviderID))
+
+		if err := m.destroyer.DestroySession(ctx, session.ID); err != nil {
+			m.logger.Error("re-destroy failed for leaked session",
+				slog.String("session_id", session.ID),
+				slog.String("provider_id", session.ProviderID),
+				slog.String("error", err.Error()))
+			continue
+		}
+
+		m.logger.Info("successfully destroyed leaked session",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID))
+
+		m.metrics.mu.Lock()
+		m.metrics.FailedDestroysRecovered++
+		m.metrics.mu.Unlock()
+
+		logging.Audit(ctx, "failed_destroy_recovered",
+			"session_id", session.ID,
+			"provider", session.Provider,
+			"provider_id", session.ProviderID)
+	}
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/service/lifecycle/ -run TestManager_CheckFailedDestroys -v`
+Expected: PASS (both subtests)
+
+**Step 5: Run all lifecycle tests to avoid regressions**
+
+Run: `go test ./internal/service/lifecycle/ -v`
+Expected: All PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/service/lifecycle/manager.go internal/service/lifecycle/manager_test.go
+git commit -m "feat: add failed-destroy watchdog to lifecycle manager
+
+Re-attempts destruction every tick for sessions marked 'failed' that
+still have a provider instance ID. Prevents leaked GPU instances from
+accumulating charges indefinitely."
+```
+
+---
+
+### Task 3: Harden graceful shutdown with fire-and-forget fallback
+
+**Files:**
+- Modify: `internal/service/lifecycle/startup.go:15-23` (change default timeout)
+- Modify: `internal/service/lifecycle/startup.go:163-283` (add fire-and-forget after timeout)
+- Test: `internal/service/lifecycle/startup_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/service/lifecycle/startup_test.go`:
+
+```go
+func TestGracefulShutdown_FireAndForgetOnTimeout(t *testing.T) {
+	// Provider that takes too long to destroy (simulating timeout)
+	slowProvider := &mockStartupProvider{
+		name:         "tensordock",
+		destroyDelay: 5 * time.Second, // Longer than our shutdown timeout
+	}
+
+	fastProvider := &mockStartupProvider{
+		name: "vastai",
+	}
+
+	store := &mockStartupStore{
+		sessions: []*models.Session{
+			{
+				ID:         "sess-slow",
+				Provider:   "tensordock",
+				ProviderID: "td-slow-1",
+				Status:     models.StatusRunning,
+			},
+			{
+				ID:         "sess-fast",
+				Provider:   "vastai",
+				ProviderID: "vast-1",
+				Status:     models.StatusRunning,
+			},
+		},
+	}
+
+	registry := &mockProviderRegistry{
+		providers: map[string]provider.Provider{
+			"tensordock": slowProvider,
+			"vastai":     fastProvider,
+		},
+	}
+
+	m := NewStartupShutdownManager(store, nil, registry,
+		WithShutdownTimeout(500*time.Millisecond)) // Very short timeout
+
+	ctx := context.Background()
+	err := m.GracefulShutdown(ctx)
+
+	// Should return error (some sessions timed out)
+	assert.Error(t, err)
+
+	// Fast provider should have been destroyed
+	assert.GreaterOrEqual(t, fastProvider.getDestroyCalls(), 1)
+
+	// Slow provider should also have received at least one call
+	// (the fire-and-forget after timeout)
+	time.Sleep(100 * time.Millisecond) // Give fire-and-forget goroutines time
+	assert.GreaterOrEqual(t, slowProvider.getDestroyCalls(), 1)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/service/lifecycle/ -run TestGracefulShutdown_FireAndForgetOnTimeout -v`
+Expected: FAIL — slow provider doesn't get the fire-and-forget call
+
+**Step 3: Write implementation**
+
+1. Change `DefaultShutdownTimeout` (line 20):
+```go
+DefaultShutdownTimeout = 120 * time.Second
+```
+
+2. Modify `GracefulShutdown` to track which sessions were not destroyed and fire-and-forget for them. Replace the select/case block at lines 245-250 with:
+
+```go
+	// Track which sessions were successfully destroyed
+	destroyedSet := make(map[string]bool)
+	var destroyedSetMu sync.Mutex
+
+	for _, session := range sessions {
+		wg.Add(1)
+		go func(s *models.Session) {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-shutdownCtx.Done():
+				m.logger.Warn("shutdown context cancelled, skipping session destroy",
+					slog.String("session_id", s.ID))
+				failedCount.Add(1)
+				return
+			}
+
+			if err := m.destroySession(shutdownCtx, s); err != nil {
+				m.logger.Error("failed to destroy session during shutdown",
+					slog.String("session_id", s.ID),
+					slog.String("provider", s.Provider),
+					slog.String("error", err.Error()))
+				failedCount.Add(1)
+			} else {
+				m.logger.Info("destroyed session during shutdown",
+					slog.String("session_id", s.ID),
+					slog.String("provider", s.Provider))
+				destroyedCount.Add(1)
+				destroyedSetMu.Lock()
+				destroyedSet[s.ID] = true
+				destroyedSetMu.Unlock()
+			}
+		}(session)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All destroys completed
+	case <-shutdownCtx.Done():
+		m.logger.Warn("shutdown context timed out, firing last-chance destroys")
+		// Fire-and-forget: attempt destroy for any session not yet confirmed destroyed
+		destroyedSetMu.Lock()
+		notDestroyed := make([]*models.Session, 0)
+		for _, s := range sessions {
+			if !destroyedSet[s.ID] {
+				notDestroyed = append(notDestroyed, s)
+			}
+		}
+		destroyedSetMu.Unlock()
+
+		for _, s := range notDestroyed {
+			m.logger.Error("LAST CHANCE: fire-and-forget destroy for session",
+				slog.String("session_id", s.ID),
+				slog.String("provider", s.Provider),
+				slog.String("provider_id", s.ProviderID))
+			go m.fireAndForgetDestroy(s)
+		}
+	}
+```
+
+3. Add the `fireAndForgetDestroy` helper:
+
+```go
+// fireAndForgetDestroy makes a single destroy attempt without verification.
+// Used as a last resort during shutdown timeout.
+func (m *StartupShutdownManager) fireAndForgetDestroy(session *models.Session) {
+	if session.ProviderID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	prov, err := m.providers.Get(session.Provider)
+	if err != nil {
+		m.logger.Error("fire-and-forget: provider not found",
+			slog.String("session_id", session.ID),
+			slog.String("provider", session.Provider))
+		return
+	}
+
+	if err := prov.DestroyInstance(ctx, session.ProviderID); err != nil {
+		m.logger.Error("fire-and-forget destroy failed",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID),
+			slog.String("error", err.Error()))
+	} else {
+		m.logger.Info("fire-and-forget destroy succeeded",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID))
+	}
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/service/lifecycle/ -run TestGracefulShutdown -v`
+Expected: All PASS
+
+**Step 5: Run all lifecycle tests**
+
+Run: `go test ./internal/service/lifecycle/ -v`
+Expected: All PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/service/lifecycle/startup.go internal/service/lifecycle/startup_test.go
+git commit -m "feat: add fire-and-forget shutdown fallback and increase timeout
+
+When graceful shutdown times out, fire one last destroy call per
+remaining session without waiting for verification. Increases default
+shutdown timeout from 60s to 120s."
+```
+
+---
+
+### Task 4: Extend startup sweep to recover failed sessions
+
+**Files:**
+- Modify: `internal/service/lifecycle/reconciler.go:404-482` (extend `RecoverStuckSessions`)
+- Modify: `internal/service/lifecycle/reconciler.go:16` (change `DefaultReconcileInterval`)
+- Test: `internal/service/lifecycle/reconciler_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/service/lifecycle/reconciler_test.go`:
+
+```go
+func TestRecoverStuckSessions_IncludesFailedWithProviderID(t *testing.T) {
+	store := newMockReconcileStore()
+	mockProv := &mockReconcileProvider{
+		name: "tensordock",
+		statusResponses: map[string]*provider.InstanceStatus{
+			"td-leaked": {Running: true, Status: "running"},
+		},
+	}
+	registry := &mockProviderRegistryForReconciler{
+		providers: map[string]provider.Provider{"tensordock": mockProv},
+	}
+
+	r := NewReconciler(store, registry)
+
+	// Add a failed session with a provider ID (leaked instance, still running)
+	store.addSession(&models.Session{
+		ID:         "sess-failed-leaked",
+		Provider:   "tensordock",
+		ProviderID: "td-leaked",
+		Status:     models.StatusFailed,
+		Error:      "Session stuck in stopping state",
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+	})
+
+	err := r.RecoverStuckSessions(context.Background())
+	require.NoError(t, err)
+
+	// Should have attempted to destroy the instance
+	assert.GreaterOrEqual(t, mockProv.destroyCalls(), 1)
+}
+```
+
+Note: You may need to adapt mock names to match existing test patterns — check `reconciler_test.go` for the exact mock types used.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/service/lifecycle/ -run TestRecoverStuckSessions_IncludesFailedWithProviderID -v`
+Expected: FAIL — `RecoverStuckSessions` doesn't query failed sessions
+
+**Step 3: Write implementation**
+
+1. Change `DefaultReconcileInterval` (line 16):
+```go
+DefaultReconcileInterval = 2 * time.Minute
+```
+
+2. Extend `RecoverStuckSessions` (around line 409-411) to also query failed sessions. After the existing stuck session recovery, add:
+
+```go
+	// Also recover failed sessions that still have provider instances
+	failedSessions, err := r.store.GetSessionsByStatus(ctx, models.StatusFailed)
+	if err != nil {
+		r.logger.Error("failed to get failed sessions for recovery",
+			slog.String("error", err.Error()))
+		// Don't return error - continue with rest of recovery
+	} else {
+		for _, session := range failedSessions {
+			if session.ProviderID == "" {
+				continue // No instance to recover
+			}
+
+			r.logger.Warn("found failed session with provider instance",
+				slog.String("session_id", session.ID),
+				slog.String("provider_id", session.ProviderID),
+				slog.String("provider", session.Provider))
+
+			prov, err := r.providers.Get(session.Provider)
+			if err != nil {
+				r.logger.Error("provider not found for failed session",
+					slog.String("session_id", session.ID),
+					slog.String("provider", session.Provider))
+				continue
+			}
+
+			// Check if instance is still running
+			status, err := prov.GetInstanceStatus(ctx, session.ProviderID)
+			if err != nil {
+				// Instance not found - clean up the session record
+				session.ProviderID = "" // Clear to prevent future re-checks
+				r.store.Update(ctx, session)
+				continue
+			}
+
+			if status.Running {
+				r.logger.Info("destroying leaked instance from failed session",
+					slog.String("session_id", session.ID),
+					slog.String("provider_id", session.ProviderID))
+				if err := prov.DestroyInstance(ctx, session.ProviderID); err != nil {
+					r.logger.Error("failed to destroy leaked instance",
+						slog.String("session_id", session.ID),
+						slog.String("error", err.Error()))
+				} else {
+					session.ProviderID = "" // Clear provider ID after successful destroy
+					session.Status = models.StatusStopped
+					session.StoppedAt = r.now()
+					r.store.Update(ctx, session)
+				}
+			} else {
+				// Instance not running - update session
+				session.ProviderID = ""
+				r.store.Update(ctx, session)
+			}
+		}
+	}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/service/lifecycle/ -run TestRecoverStuckSessions -v`
+Expected: All PASS
+
+**Step 5: Run all lifecycle tests**
+
+Run: `go test ./internal/service/lifecycle/ -v`
+Expected: All PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/service/lifecycle/reconciler.go internal/service/lifecycle/reconciler_test.go
+git commit -m "feat: extend startup sweep to recover failed sessions, reduce reconcile interval
+
+RecoverStuckSessions now also checks failed sessions with provider IDs
+and destroys any still-running instances. Reconcile interval reduced
+from 5min to 2min for faster orphan detection."
+```
+
+---
+
+### Task 5: Log unknown TensorDock instances
+
+**Files:**
+- Modify: `internal/provider/tensordock/client.go:902-921` (add warning log)
+- Test: `internal/provider/tensordock/client_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/provider/tensordock/client_test.go`:
+
+```go
+func TestClient_instancesToProviderInstances_LogsUnknown(t *testing.T) {
+	// Create a client with a logger that captures output
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	client := &Client{logger: logger}
+
+	instances := []Instance{
+		{ID: "td-1", Name: "shopper-sess-1", Status: "running"},
+		{ID: "td-2", Name: "unknown-instance", Status: "running"},
+		{ID: "td-3", Name: "my-other-vm", Status: "stopped"},
+	}
+
+	result := client.instancesToProviderInstances(instances)
+
+	// Should only return the shopper instance
+	assert.Len(t, result, 1)
+	assert.Equal(t, "td-1", result[0].ID)
+
+	// Should have logged warnings about the unknown instances
+	logOutput := buf.String()
+	assert.Contains(t, logOutput, "unknown-instance")
+	assert.Contains(t, logOutput, "td-2")
+	assert.Contains(t, logOutput, "my-other-vm")
+	assert.Contains(t, logOutput, "td-3")
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/provider/tensordock/ -run TestClient_instancesToProviderInstances_LogsUnknown -v`
+Expected: FAIL — no log output for unknown instances
+
+**Step 3: Write implementation**
+
+Modify `instancesToProviderInstances` in `internal/provider/tensordock/client.go` (lines 902-921):
+
+```go
+func (c *Client) instancesToProviderInstances(instances []Instance) []provider.ProviderInstance {
+	result := make([]provider.ProviderInstance, 0)
+	for _, inst := range instances {
+		if sessionID, ok := models.ParseLabel(inst.Name); ok {
+			result = append(result, provider.ProviderInstance{
+				ID:        inst.ID,
+				Name:      inst.Name,
+				Status:    inst.Status,
+				StartedAt: inst.CreatedAt,
+				Tags: models.InstanceTags{
+					ShopperSessionID: sessionID,
+				},
+				PricePerHour: inst.PricePerHour,
+			})
+		} else {
+			c.logger.Warn("TensorDock instance without shopper prefix detected",
+				slog.String("instance_id", inst.ID),
+				slog.String("instance_name", inst.Name),
+				slog.String("status", inst.Status))
+		}
+	}
+	return result
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/provider/tensordock/ -run TestClient_instancesToProviderInstances_LogsUnknown -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/provider/tensordock/client.go internal/provider/tensordock/client_test.go
+git commit -m "feat: log unknown TensorDock instances during reconciliation
+
+Instances without the 'shopper-' prefix are now logged at WARN level
+with their ID and name, providing visibility into potentially leaked
+instances."
+```
+
+---
+
+### Task 6: Add `BalanceProvider` interface and Vast.ai implementation
+
+**Files:**
+- Modify: `internal/provider/interface.go:86` (add interface after `Provider`)
+- Modify: `internal/provider/vastai/client.go` (implement `GetAccountBalance`)
+- Test: `internal/provider/vastai/client_test.go`
+
+**Step 1: Add interface**
+
+Add to `internal/provider/interface.go` after the `Provider` interface (after line 85):
+
+```go
+// BalanceProvider is an optional interface for providers that support account balance checking.
+// Used to warn before provisioning when account balance is low.
+type BalanceProvider interface {
+	GetAccountBalance(ctx context.Context) (*AccountBalance, error)
+}
+
+// AccountBalance represents a provider account's current balance.
+type AccountBalance struct {
+	Balance  float64 // Current balance in provider's currency
+	Currency string  // Currency code (e.g., "USD")
+}
+
+// ErrBalanceNotSupported indicates a provider doesn't support balance checking.
+var ErrBalanceNotSupported = errors.New("balance checking not supported by this provider")
+```
+
+**Step 2: Write the failing test for Vast.ai**
+
+Add to `internal/provider/vastai/client_test.go`:
+
+```go
+func TestClient_GetAccountBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/users/current/" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"credit": 42.50,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+
+	balance, err := client.GetAccountBalance(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, 42.50, balance.Balance, 0.01)
+	assert.Equal(t, "USD", balance.Currency)
+}
+
+func TestClient_GetAccountBalance_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient("bad-key", WithBaseURL(server.URL))
+
+	_, err := client.GetAccountBalance(context.Background())
+	assert.Error(t, err)
+}
+```
+
+**Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/provider/vastai/ -run TestClient_GetAccountBalance -v`
+Expected: FAIL — `GetAccountBalance` not defined
+
+**Step 4: Write Vast.ai implementation**
+
+Add to `internal/provider/vastai/client.go`:
+
+```go
+// GetAccountBalance returns the current Vast.ai account balance.
+// Implements the provider.BalanceProvider interface.
+func (c *Client) GetAccountBalance(ctx context.Context) (*provider.AccountBalance, error) {
+	if err := c.rateLimit(ctx); err != nil {
+		return nil, fmt.Errorf("rate limit wait: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/users/current/", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("balance check failed: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Credit float64 `json:"credit"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return &provider.AccountBalance{
+		Balance:  result.Credit,
+		Currency: "USD",
+	}, nil
+}
+```
+
+**Step 5: Run tests**
+
+Run: `go test ./internal/provider/vastai/ -run TestClient_GetAccountBalance -v`
+Expected: PASS
+
+**Step 6: Verify compile-time interface satisfaction**
+
+Add to the top of `internal/provider/vastai/client.go` (near other compile-time checks):
+
+```go
+var _ provider.BalanceProvider = (*Client)(nil)
+```
+
+**Step 7: Commit**
+
+```bash
+git add internal/provider/interface.go internal/provider/vastai/client.go internal/provider/vastai/client_test.go
+git commit -m "feat: add BalanceProvider interface with Vast.ai implementation
+
+New optional BalanceProvider interface for checking account balance
+before provisioning. Vast.ai implements it using /users/current/.
+TensorDock and Blue Lobster don't support it yet."
+```
+
+---
+
+### Task 7: Add pre-provision balance warning to provisioner
+
+**Files:**
+- Modify: `internal/service/provisioner/service.go:60` (add constant)
+- Modify: `internal/service/provisioner/service.go:365-370` (add balance check)
+- Test: `internal/service/provisioner/service_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `internal/service/provisioner/service_test.go`:
+
+```go
+func TestCreateSession_WarnsOnLowBalance(t *testing.T) {
+	// This test verifies the provisioner logs a warning when balance is low
+	// but still proceeds with provisioning (warn-only behavior).
+	// The actual assertion is that provisioning proceeds — the warning
+	// is tested indirectly through the balance check being called.
+
+	// Set up a mock provider that implements BalanceProvider
+	// with a low balance of $2.00
+	mockProv := &mockProviderWithBalance{
+		Provider: &mockProvider{name: "vastai"},
+		balance:  2.00,
+	}
+
+	// ... (wire up provisioner with mock, call CreateSession)
+	// The key assertion: CreateSession should succeed (not block)
+	// even though balance is low
+}
+```
+
+Note: This test will need to work within the existing test patterns in `service_test.go`. Study the existing `TestCreateSession` tests to match the mock setup patterns. The critical behavior to test is:
+1. When provider implements `BalanceProvider` and balance < threshold → provisioning proceeds (warn-only)
+2. When provider does not implement `BalanceProvider` → provisioning proceeds normally (no error)
+
+**Step 2: Write implementation**
+
+1. Add constant (after line ~60):
+```go
+// DefaultLowBalanceThreshold is the balance below which a warning is logged
+DefaultLowBalanceThreshold = 5.00
+```
+
+2. Add field to `Service` struct:
+```go
+lowBalanceThreshold float64
+```
+
+3. Initialize in `New()`:
+```go
+lowBalanceThreshold: DefaultLowBalanceThreshold,
+```
+
+4. Add balance check at the start of `createSessionWithRetry` (after line 370, before the main provisioning logic):
+
+```go
+	// Check provider balance (warn-only)
+	prov, err := s.providers.Get(offer.Provider)
+	if err == nil {
+		if bp, ok := prov.(provider.BalanceProvider); ok {
+			if balance, err := bp.GetAccountBalance(ctx); err == nil {
+				if balance.Balance < s.lowBalanceThreshold {
+					s.logger.Warn("LOW BALANCE: provider account balance is below threshold",
+						slog.String("provider", offer.Provider),
+						slog.Float64("balance", balance.Balance),
+						slog.Float64("threshold", s.lowBalanceThreshold),
+						slog.String("currency", balance.Currency))
+				}
+			} else {
+				s.logger.Debug("could not check provider balance",
+					slog.String("provider", offer.Provider),
+					slog.String("error", err.Error()))
+			}
+		}
+	}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/service/provisioner/ -v`
+Expected: All PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/service/provisioner/service.go internal/service/provisioner/service_test.go
+git commit -m "feat: add pre-provision balance warning
+
+Checks provider account balance before provisioning and logs a WARNING
+when below threshold ($5 default). Warn-only — does not block
+provisioning. Gracefully skipped for providers that don't implement
+BalanceProvider."
+```
+
+---
+
+### Task 8: Final validation
+
+**Step 1: Run full test suite**
+
+Run: `go test ./... 2>&1 | tail -30`
+Expected: All PASS, no new failures
+
+**Step 2: Run go vet**
+
+Run: `go vet ./...`
+Expected: No issues
+
+**Step 3: Check formatting**
+
+Run: `gofmt -l .`
+Expected: No output (all formatted)
+
+**Step 4: Final commit if any formatting fixes needed**
+
+```bash
+gofmt -w .
+git add -A
+git commit -m "style: fix formatting"
+```

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -146,6 +146,10 @@ func (m *mockSessionStore) GetExpiredSessions(ctx context.Context) ([]*models.Se
 	return nil, nil
 }
 
+func (m *mockSessionStore) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	return nil, nil
+}
+
 func (m *mockSessionStore) GetSessionsByStatus(ctx context.Context, statuses ...models.SessionStatus) ([]*models.Session, error) {
 	return nil, nil
 }

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -84,6 +84,20 @@ type Provider interface {
 	SupportsFeature(feature ProviderFeature) bool
 }
 
+// BalanceProvider is an optional interface for providers that support account balance checking.
+type BalanceProvider interface {
+	GetAccountBalance(ctx context.Context) (*AccountBalance, error)
+}
+
+// AccountBalance represents a provider account's current balance.
+type AccountBalance struct {
+	Balance  float64 // Current balance in provider's currency
+	Currency string  // Currency code (e.g., "USD")
+}
+
+// ErrBalanceNotSupported indicates a provider doesn't support balance checking.
+var ErrBalanceNotSupported = errors.New("balance checking not supported by this provider")
+
 // TemplateProvider extends Provider with template management capabilities.
 // Only providers that support templates (e.g., Vast.ai) implement this interface.
 type TemplateProvider interface {

--- a/internal/provider/tensordock/client.go
+++ b/internal/provider/tensordock/client.go
@@ -915,6 +915,11 @@ func (c *Client) instancesToProviderInstances(instances []Instance) []provider.P
 				},
 				PricePerHour: inst.PricePerHour,
 			})
+		} else {
+			c.logger.Warn("TensorDock instance without shopper prefix detected",
+				slog.String("instance_id", inst.ID),
+				slog.String("instance_name", inst.Name),
+				slog.String("status", inst.Status))
 		}
 	}
 	return result

--- a/internal/provider/tensordock/client_test.go
+++ b/internal/provider/tensordock/client_test.go
@@ -1,8 +1,10 @@
 package tensordock
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -855,4 +857,54 @@ func TestLocationGPUToOffer(t *testing.T) {
 	assert.Equal(t, 0.40, offer.PricePerHour)
 	assert.Contains(t, offer.Location, "TestCity")
 	assert.InDelta(t, 0.67, offer.Reliability, 0.01) // Tier 2/3
+}
+
+func TestInstancesToProviderInstances_LogsUnknownInstances(t *testing.T) {
+	// Create a logger that writes to a buffer so we can inspect log output
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	client := NewClient("test-key", "test-token", WithLogger(logger))
+
+	instances := []Instance{
+		{
+			ID:           "inst-001",
+			Name:         "shopper-session-abc",
+			Status:       "running",
+			PricePerHour: 0.50,
+		},
+		{
+			ID:     "inst-002",
+			Name:   "my-personal-vm",
+			Status: "running",
+		},
+		{
+			ID:           "inst-003",
+			Name:         "shopper-session-def",
+			Status:       "stopped",
+			PricePerHour: 0.30,
+		},
+		{
+			ID:     "inst-004",
+			Name:   "test-instance",
+			Status: "creating",
+		},
+	}
+
+	result := client.instancesToProviderInstances(instances)
+
+	// Only shopper-prefixed instances should be returned
+	require.Len(t, result, 2)
+	assert.Equal(t, "inst-001", result[0].ID)
+	assert.Equal(t, "session-abc", result[0].Tags.ShopperSessionID)
+	assert.Equal(t, "inst-003", result[1].ID)
+	assert.Equal(t, "session-def", result[1].Tags.ShopperSessionID)
+
+	// Verify warning logs contain the unknown instance details
+	logOutput := logBuf.String()
+	assert.Contains(t, logOutput, "inst-002")
+	assert.Contains(t, logOutput, "my-personal-vm")
+	assert.Contains(t, logOutput, "inst-004")
+	assert.Contains(t, logOutput, "test-instance")
+	assert.Contains(t, logOutput, "TensorDock instance without shopper prefix detected")
 }

--- a/internal/provider/vastai/client.go
+++ b/internal/provider/vastai/client.go
@@ -192,6 +192,9 @@ type bundleCache struct {
 	mu        sync.RWMutex
 }
 
+// Compile-time interface checks
+var _ provider.BalanceProvider = (*Client)(nil)
+
 // Client implements the provider.Provider interface for Vast.ai
 type Client struct {
 	apiKey     string
@@ -993,6 +996,46 @@ func (c *Client) GetTemplate(ctx context.Context, hashID string) (*models.VastTe
 // Returns an error if the context is cancelled while waiting.
 func (c *Client) rateLimit(ctx context.Context) error {
 	return c.limiter.Wait(ctx)
+}
+
+// GetAccountBalance returns the current account credit balance from Vast.ai.
+// It calls the /users/current/ endpoint and extracts the credit field.
+func (c *Client) GetAccountBalance(ctx context.Context) (*provider.AccountBalance, error) {
+	if err := c.rateLimit(ctx); err != nil {
+		return nil, fmt.Errorf("rate limit wait: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/users/current/", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("balance check failed: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Credit float64 `json:"credit"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return &provider.AccountBalance{
+		Balance:  result.Credit,
+		Currency: "USD",
+	}, nil
 }
 
 // handleError converts HTTP errors to provider errors

--- a/internal/provider/vastai/client_test.go
+++ b/internal/provider/vastai/client_test.go
@@ -1034,3 +1034,41 @@ func TestTemplate_ToModel(t *testing.T) {
 	// CreatedAt should be converted from Unix timestamp
 	assert.False(t, model.CreatedAt.IsZero())
 }
+
+func TestClient_GetAccountBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/users/current/", r.URL.Path)
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"credit": 42.50,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", WithBaseURL(server.URL), WithMinInterval(0))
+
+	balance, err := client.GetAccountBalance(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 42.50, balance.Balance)
+	assert.Equal(t, "USD", balance.Currency)
+}
+
+func TestClient_GetAccountBalance_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("unauthorized"))
+	}))
+	defer server.Close()
+
+	client := NewClient("bad-key", WithBaseURL(server.URL), WithMinInterval(0))
+
+	balance, err := client.GetAccountBalance(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, balance)
+	assert.Contains(t, err.Error(), "balance check failed: status 401")
+}

--- a/internal/service/lifecycle/manager.go
+++ b/internal/service/lifecycle/manager.go
@@ -36,6 +36,7 @@ type SessionStore interface {
 	GetActiveSessions(ctx context.Context) ([]*models.Session, error)
 	GetExpiredSessions(ctx context.Context) ([]*models.Session, error)
 	GetSessionsByStatus(ctx context.Context, statuses ...models.SessionStatus) ([]*models.Session, error)
+	GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error)
 	Get(ctx context.Context, id string) (*models.Session, error)
 	Update(ctx context.Context, session *models.Session) error
 }
@@ -94,15 +95,16 @@ type Manager struct {
 
 // Metrics tracks lifecycle manager statistics
 type Metrics struct {
-	mu                    sync.RWMutex
-	ChecksRun             int64
-	SessionsExpired       int64
-	HardMaxEnforced       int64
-	OrphansDetected       int64
-	DestroySuccesses      int64
-	DestroyFailures       int64
-	SSHHealthChecksRun    int64
-	SSHHealthChecksFailed int64
+	mu                      sync.RWMutex
+	ChecksRun               int64
+	SessionsExpired         int64
+	HardMaxEnforced         int64
+	OrphansDetected         int64
+	DestroySuccesses        int64
+	DestroyFailures         int64
+	SSHHealthChecksRun      int64
+	SSHHealthChecksFailed   int64
+	FailedDestroysRecovered int64
 }
 
 // Option configures the lifecycle manager
@@ -286,6 +288,7 @@ func (m *Manager) runChecks(ctx context.Context) {
 	m.checkReservationExpiry(ctx)
 	m.checkOrphans(ctx)
 	m.checkStuckSessions(ctx) // Bug #103 fix: Check for stuck sessions
+	m.checkFailedDestroys(ctx)
 
 	// Run SSH health check if enabled and interval has passed
 	// Bug #17 fix: Protect lastSSHHealthCheck with mutex
@@ -558,6 +561,46 @@ func (m *Manager) destroySession(ctx context.Context, session *models.Session, r
 	m.metrics.mu.Unlock()
 }
 
+// checkFailedDestroys re-attempts destruction for sessions marked failed that still
+// have a provider instance ID. These are sessions where the initial destroy failed
+// but the provider instance may still be running and accumulating charges.
+func (m *Manager) checkFailedDestroys(ctx context.Context) {
+	sessions, err := m.store.GetFailedSessionsWithInstances(ctx)
+	if err != nil {
+		m.logger.Error("failed to get failed sessions for re-destroy",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	for _, session := range sessions {
+		m.logger.Info("re-attempting destroy for failed session",
+			slog.String("session_id", session.ID),
+			slog.String("provider", session.Provider),
+			slog.String("provider_id", session.ProviderID))
+
+		if err := m.destroyer.DestroySession(ctx, session.ID); err != nil {
+			m.logger.Error("re-destroy failed for leaked session",
+				slog.String("session_id", session.ID),
+				slog.String("provider_id", session.ProviderID),
+				slog.String("error", err.Error()))
+			continue
+		}
+
+		m.logger.Info("successfully destroyed leaked session",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID))
+
+		m.metrics.mu.Lock()
+		m.metrics.FailedDestroysRecovered++
+		m.metrics.mu.Unlock()
+
+		logging.Audit(ctx, "failed_destroy_recovered",
+			"session_id", session.ID,
+			"provider", session.Provider,
+			"provider_id", session.ProviderID)
+	}
+}
+
 // SignalDone signals that a session has completed its work
 func (m *Manager) SignalDone(ctx context.Context, sessionID string) error {
 	session, err := m.store.Get(ctx, sessionID)
@@ -642,14 +685,15 @@ func (m *Manager) GetMetrics() Metrics {
 	defer m.metrics.mu.RUnlock()
 
 	return Metrics{
-		ChecksRun:             m.metrics.ChecksRun,
-		SessionsExpired:       m.metrics.SessionsExpired,
-		HardMaxEnforced:       m.metrics.HardMaxEnforced,
-		OrphansDetected:       m.metrics.OrphansDetected,
-		DestroySuccesses:      m.metrics.DestroySuccesses,
-		DestroyFailures:       m.metrics.DestroyFailures,
-		SSHHealthChecksRun:    m.metrics.SSHHealthChecksRun,
-		SSHHealthChecksFailed: m.metrics.SSHHealthChecksFailed,
+		ChecksRun:               m.metrics.ChecksRun,
+		SessionsExpired:         m.metrics.SessionsExpired,
+		HardMaxEnforced:         m.metrics.HardMaxEnforced,
+		OrphansDetected:         m.metrics.OrphansDetected,
+		DestroySuccesses:        m.metrics.DestroySuccesses,
+		DestroyFailures:         m.metrics.DestroyFailures,
+		SSHHealthChecksRun:      m.metrics.SSHHealthChecksRun,
+		SSHHealthChecksFailed:   m.metrics.SSHHealthChecksFailed,
+		FailedDestroysRecovered: m.metrics.FailedDestroysRecovered,
 	}
 }
 

--- a/internal/service/lifecycle/manager_test.go
+++ b/internal/service/lifecycle/manager_test.go
@@ -66,6 +66,19 @@ func (m *mockSessionStore) GetExpiredSessions(ctx context.Context) ([]*models.Se
 	return result, nil
 }
 
+func (m *mockSessionStore) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*models.Session
+	for _, s := range m.sessions {
+		if s.Status == models.StatusFailed && s.ProviderID != "" {
+			copy := *s
+			result = append(result, &copy)
+		}
+	}
+	return result, nil
+}
+
 func (m *mockSessionStore) GetSessionsByStatus(ctx context.Context, statuses ...models.SessionStatus) ([]*models.Session, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -329,6 +342,19 @@ func (m *mockSessionStoreWithExpiry) GetExpiredSessions(ctx context.Context) ([]
 	var result []*models.Session
 	for _, s := range m.sessions {
 		if s.Status == models.StatusRunning && m.now.After(s.ExpiresAt) {
+			copy := *s
+			result = append(result, &copy)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSessionStoreWithExpiry) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*models.Session
+	for _, s := range m.sessions {
+		if s.Status == models.StatusFailed && s.ProviderID != "" {
 			copy := *s
 			result = append(result, &copy)
 		}
@@ -769,4 +795,101 @@ func TestManager_TimeInjection_OrphanGracePeriod(t *testing.T) {
 	m.checkOrphans(ctx)
 	assert.Len(t, handler.orphanSessions, 1, "orphan detected after grace period")
 	assert.Equal(t, "sess-orphan-grace", handler.orphanSessions[0].ID)
+}
+
+// TestManager_CheckFailedDestroys verifies that checkFailedDestroys re-attempts
+// destruction for failed sessions that still have a provider instance ID.
+func TestManager_CheckFailedDestroys(t *testing.T) {
+	store := newMockSessionStore()
+	destroyer := newMockDestroyer()
+
+	now := time.Now()
+
+	// Failed session WITH provider instance ID — should be re-destroyed
+	failedWithInstance := &models.Session{
+		ID:         "sess-failed-leak",
+		Status:     models.StatusFailed,
+		Provider:   "vastai",
+		ProviderID: "inst-12345",
+		CreatedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt:  now.Add(-1 * time.Hour),
+	}
+	store.add(failedWithInstance)
+
+	// Failed session WITHOUT provider instance ID — should be skipped
+	failedNoInstance := &models.Session{
+		ID:        "sess-failed-clean",
+		Status:    models.StatusFailed,
+		Provider:  "vastai",
+		CreatedAt: now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+	}
+	store.add(failedNoInstance)
+
+	// Running session — should not be picked up
+	runningSession := &models.Session{
+		ID:         "sess-running",
+		Status:     models.StatusRunning,
+		Provider:   "vastai",
+		ProviderID: "inst-99999",
+		CreatedAt:  now.Add(-1 * time.Hour),
+		ExpiresAt:  now.Add(1 * time.Hour),
+	}
+	store.add(runningSession)
+
+	m := New(store, destroyer,
+		WithLogger(newTestLogger()),
+		WithTimeFunc(func() time.Time { return now }))
+
+	ctx := context.Background()
+	m.checkFailedDestroys(ctx)
+
+	// Only the failed session with a provider ID should be destroyed
+	calls := destroyer.getDestroyCalls()
+	assert.Equal(t, []string{"sess-failed-leak"}, calls)
+
+	// Verify metric was incremented
+	metrics := m.GetMetrics()
+	assert.Equal(t, int64(1), metrics.FailedDestroysRecovered)
+}
+
+// TestManager_CheckFailedDestroys_DestroyFails verifies that when the re-destroy
+// attempt fails, the session stays in failed state and the metric is NOT incremented.
+func TestManager_CheckFailedDestroys_DestroyFails(t *testing.T) {
+	store := newMockSessionStore()
+	destroyer := newMockDestroyer()
+	destroyer.err = errors.New("provider API unavailable")
+
+	now := time.Now()
+
+	failedSession := &models.Session{
+		ID:         "sess-failed-retry",
+		Status:     models.StatusFailed,
+		Provider:   "tensordock",
+		ProviderID: "td-instance-42",
+		CreatedAt:  now.Add(-3 * time.Hour),
+		ExpiresAt:  now.Add(-2 * time.Hour),
+	}
+	store.add(failedSession)
+
+	m := New(store, destroyer,
+		WithLogger(newTestLogger()),
+		WithTimeFunc(func() time.Time { return now }))
+
+	ctx := context.Background()
+	m.checkFailedDestroys(ctx)
+
+	// Destroyer was called but failed
+	calls := destroyer.getDestroyCalls()
+	assert.Equal(t, []string{"sess-failed-retry"}, calls)
+
+	// Metric should NOT be incremented on failure
+	metrics := m.GetMetrics()
+	assert.Equal(t, int64(0), metrics.FailedDestroysRecovered)
+
+	// Session should still be in failed status (unchanged)
+	session, err := store.Get(ctx, "sess-failed-retry")
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusFailed, session.Status)
+	assert.Equal(t, "td-instance-42", session.ProviderID)
 }

--- a/internal/service/lifecycle/reconciler.go
+++ b/internal/service/lifecycle/reconciler.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultReconcileInterval is how often to run reconciliation
-	DefaultReconcileInterval = 5 * time.Minute
+	DefaultReconcileInterval = 2 * time.Minute
 )
 
 // ProviderRegistry provides access to provider clients
@@ -475,6 +475,57 @@ func (r *Reconciler) RecoverStuckSessions(ctx context.Context) error {
 			session.Status = models.StatusStopped
 			session.StoppedAt = r.now()
 			r.store.Update(ctx, session)
+		}
+	}
+
+	// Also recover failed sessions that still have provider instances
+	failedSessions, err := r.store.GetSessionsByStatus(ctx, models.StatusFailed)
+	if err != nil {
+		r.logger.Error("failed to get failed sessions for recovery",
+			slog.String("error", err.Error()))
+	} else {
+		for _, session := range failedSessions {
+			if session.ProviderID == "" {
+				continue
+			}
+			r.logger.Warn("found failed session with provider instance",
+				slog.String("session_id", session.ID),
+				slog.String("provider_id", session.ProviderID),
+				slog.String("provider", session.Provider))
+
+			prov, err := r.providers.Get(session.Provider)
+			if err != nil {
+				r.logger.Error("provider not found for failed session",
+					slog.String("session_id", session.ID),
+					slog.String("provider", session.Provider))
+				continue
+			}
+
+			status, err := prov.GetInstanceStatus(ctx, session.ProviderID)
+			if err != nil {
+				session.ProviderID = ""
+				r.store.Update(ctx, session)
+				continue
+			}
+
+			if status.Running {
+				r.logger.Info("destroying leaked instance from failed session",
+					slog.String("session_id", session.ID),
+					slog.String("provider_id", session.ProviderID))
+				if err := prov.DestroyInstance(ctx, session.ProviderID); err != nil {
+					r.logger.Error("failed to destroy leaked instance",
+						slog.String("session_id", session.ID),
+						slog.String("error", err.Error()))
+				} else {
+					session.ProviderID = ""
+					session.Status = models.StatusStopped
+					session.StoppedAt = r.now()
+					r.store.Update(ctx, session)
+				}
+			} else {
+				session.ProviderID = ""
+				r.store.Update(ctx, session)
+			}
 		}
 	}
 

--- a/internal/service/lifecycle/reconciler_test.go
+++ b/internal/service/lifecycle/reconciler_test.go
@@ -574,6 +574,154 @@ func TestReconciler_RecoverStuckStopping(t *testing.T) {
 	assert.Equal(t, []string{"still-running"}, prov.getDestroyCalls())
 }
 
+func TestRecoverStuckSessions_IncludesFailedWithProviderID(t *testing.T) {
+	store := newMockReconcileStore()
+	registry := newMockProviderRegistry()
+
+	fixedTime := time.Date(2026, 2, 23, 12, 0, 0, 0, time.UTC)
+
+	// Failed session that still has a provider instance running
+	failedSession := &models.Session{
+		ID:         "failed-session",
+		Provider:   "vastai",
+		ProviderID: "leaked-instance",
+		Status:     models.StatusFailed,
+		Error:      "some provisioning error",
+	}
+	store.add(failedSession)
+
+	prov := newMockReconcileProvider("vastai")
+	prov.statusFn = func(id string) (*provider.InstanceStatus, error) {
+		return &provider.InstanceStatus{
+			Status:  "running",
+			Running: true,
+		}, nil
+	}
+	registry.Add(prov)
+
+	r := NewReconciler(store, registry,
+		WithReconcileLogger(newTestLogger()),
+		WithReconcileTimeFunc(func() time.Time { return fixedTime }))
+
+	ctx := context.Background()
+	err := r.RecoverStuckSessions(ctx)
+	require.NoError(t, err)
+
+	// DestroyInstance should have been called for the leaked instance
+	assert.Equal(t, []string{"leaked-instance"}, prov.getDestroyCalls())
+
+	// Session should be updated: provider ID cleared, status stopped
+	updated, err := store.Get(ctx, "failed-session")
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusStopped, updated.Status)
+	assert.Empty(t, updated.ProviderID)
+	assert.Equal(t, fixedTime, updated.StoppedAt)
+}
+
+func TestRecoverStuckSessions_FailedWithProviderID_InstanceNotFound(t *testing.T) {
+	store := newMockReconcileStore()
+	registry := newMockProviderRegistry()
+
+	// Failed session whose provider instance no longer exists
+	failedSession := &models.Session{
+		ID:         "failed-session",
+		Provider:   "vastai",
+		ProviderID: "gone-instance",
+		Status:     models.StatusFailed,
+	}
+	store.add(failedSession)
+
+	prov := newMockReconcileProvider("vastai")
+	// Default statusFn returns ErrInstanceNotFound
+	registry.Add(prov)
+
+	r := NewReconciler(store, registry,
+		WithReconcileLogger(newTestLogger()))
+
+	ctx := context.Background()
+	err := r.RecoverStuckSessions(ctx)
+	require.NoError(t, err)
+
+	// No destroy call needed - instance already gone
+	assert.Empty(t, prov.getDestroyCalls())
+
+	// Provider ID should be cleared
+	updated, err := store.Get(ctx, "failed-session")
+	require.NoError(t, err)
+	assert.Empty(t, updated.ProviderID)
+	// Status stays failed since instance wasn't running
+	assert.Equal(t, models.StatusFailed, updated.Status)
+}
+
+func TestRecoverStuckSessions_FailedWithProviderID_InstanceStopped(t *testing.T) {
+	store := newMockReconcileStore()
+	registry := newMockProviderRegistry()
+
+	// Failed session whose provider instance exists but is not running
+	failedSession := &models.Session{
+		ID:         "failed-session",
+		Provider:   "vastai",
+		ProviderID: "stopped-instance",
+		Status:     models.StatusFailed,
+	}
+	store.add(failedSession)
+
+	prov := newMockReconcileProvider("vastai")
+	prov.statusFn = func(id string) (*provider.InstanceStatus, error) {
+		return &provider.InstanceStatus{
+			Status:  "exited",
+			Running: false,
+		}, nil
+	}
+	registry.Add(prov)
+
+	r := NewReconciler(store, registry,
+		WithReconcileLogger(newTestLogger()))
+
+	ctx := context.Background()
+	err := r.RecoverStuckSessions(ctx)
+	require.NoError(t, err)
+
+	// No destroy needed
+	assert.Empty(t, prov.getDestroyCalls())
+
+	// Provider ID should be cleared
+	updated, err := store.Get(ctx, "failed-session")
+	require.NoError(t, err)
+	assert.Empty(t, updated.ProviderID)
+}
+
+func TestRecoverStuckSessions_FailedWithNoProviderID_Skipped(t *testing.T) {
+	store := newMockReconcileStore()
+	registry := newMockProviderRegistry()
+
+	// Failed session with no provider ID should be skipped
+	failedSession := &models.Session{
+		ID:       "failed-no-provider",
+		Provider: "vastai",
+		Status:   models.StatusFailed,
+	}
+	store.add(failedSession)
+
+	prov := newMockReconcileProvider("vastai")
+	registry.Add(prov)
+
+	r := NewReconciler(store, registry,
+		WithReconcileLogger(newTestLogger()))
+
+	ctx := context.Background()
+	err := r.RecoverStuckSessions(ctx)
+	require.NoError(t, err)
+
+	// No destroy calls
+	assert.Empty(t, prov.getDestroyCalls())
+
+	// Session unchanged
+	updated, err := store.Get(ctx, "failed-no-provider")
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusFailed, updated.Status)
+}
+
 func TestReconciler_MultipleProviders(t *testing.T) {
 	store := newMockReconcileStore()
 	registry := newMockProviderRegistry()

--- a/internal/service/lifecycle/startup.go
+++ b/internal/service/lifecycle/startup.go
@@ -17,7 +17,7 @@ const (
 	DefaultStartupSweepTimeout = 2 * time.Minute
 
 	// DefaultShutdownTimeout is the default timeout for graceful shutdown
-	DefaultShutdownTimeout = 60 * time.Second
+	DefaultShutdownTimeout = 120 * time.Second
 
 	// MaxParallelDestroys is the maximum number of concurrent destroy operations
 	MaxParallelDestroys = 5
@@ -162,6 +162,8 @@ func (m *StartupShutdownManager) RunStartupSweep(ctx context.Context) error {
 
 // GracefulShutdown destroys all active sessions before shutdown.
 // This method blocks until all sessions are destroyed or the context is cancelled.
+// After timeout, any sessions not yet destroyed receive a fire-and-forget last-chance
+// destroy call with a short 10s timeout.
 func (m *StartupShutdownManager) GracefulShutdown(ctx context.Context) error {
 	m.logger.Info("starting graceful shutdown",
 		slog.Duration("timeout", m.shutdownTimeout))
@@ -199,10 +201,13 @@ func (m *StartupShutdownManager) GracefulShutdown(ctx context.Context) error {
 	m.logger.Info("destroying active sessions during shutdown",
 		slog.Int("count", len(sessions)))
 
+	// Track which sessions were successfully destroyed
+	var destroyedMu sync.Mutex
+	destroyedSet := make(map[string]bool, len(sessions))
+
 	// Destroy sessions concurrently with a semaphore to limit parallelism
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, MaxParallelDestroys)
-	var destroyedCount, failedCount atomic.Int64
 
 	for _, session := range sessions {
 		wg.Add(1)
@@ -216,7 +221,6 @@ func (m *StartupShutdownManager) GracefulShutdown(ctx context.Context) error {
 			case <-shutdownCtx.Done():
 				m.logger.Warn("shutdown context cancelled, skipping session destroy",
 					slog.String("session_id", s.ID))
-				failedCount.Add(1)
 				return
 			}
 
@@ -225,33 +229,60 @@ func (m *StartupShutdownManager) GracefulShutdown(ctx context.Context) error {
 					slog.String("session_id", s.ID),
 					slog.String("provider", s.Provider),
 					slog.String("error", err.Error()))
-				failedCount.Add(1)
 			} else {
 				m.logger.Info("destroyed session during shutdown",
 					slog.String("session_id", s.ID),
 					slog.String("provider", s.Provider))
-				destroyedCount.Add(1)
+				destroyedMu.Lock()
+				destroyedSet[s.ID] = true
+				destroyedMu.Unlock()
 			}
 		}(session)
 	}
 
-	// Wait for all destroys to complete
+	// Wait for all destroys to complete or timeout
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
 
+	timedOut := false
 	select {
 	case <-done:
 		// All destroys completed
 	case <-shutdownCtx.Done():
+		timedOut = true
 		m.logger.Warn("shutdown context timed out, some sessions may not be destroyed")
 	}
 
+	// Fire-and-forget last-chance destroys for sessions that were NOT destroyed
+	if timedOut {
+		destroyedMu.Lock()
+		var remaining []*models.Session
+		for _, s := range sessions {
+			if !destroyedSet[s.ID] {
+				remaining = append(remaining, s)
+			}
+		}
+		destroyedMu.Unlock()
+
+		if len(remaining) > 0 {
+			m.logger.Warn("firing last-chance destroy for remaining sessions",
+				slog.Int("count", len(remaining)))
+			for _, s := range remaining {
+				go m.fireAndForgetDestroy(s)
+			}
+		}
+	}
+
+	// Compute final counts from the destroyed set (race-free)
+	destroyedMu.Lock()
+	destroyed := int64(len(destroyedSet))
+	destroyedMu.Unlock()
+	failed := int64(len(sessions)) - destroyed
+
 	elapsed := time.Since(start)
-	destroyed := destroyedCount.Load()
-	failed := failedCount.Load()
 
 	m.metrics.mu.Lock()
 	m.metrics.ShutdownSuccess = failed == 0
@@ -280,6 +311,33 @@ func (m *StartupShutdownManager) GracefulShutdown(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// fireAndForgetDestroy makes a single last-chance destroy attempt with a short timeout.
+// It uses a fresh context (not the cancelled shutdown context) and does not block.
+func (m *StartupShutdownManager) fireAndForgetDestroy(session *models.Session) {
+	if session.ProviderID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	prov, err := m.providers.Get(session.Provider)
+	if err != nil {
+		m.logger.Error("fire-and-forget: provider not found",
+			slog.String("session_id", session.ID),
+			slog.String("provider", session.Provider))
+		return
+	}
+	if err := prov.DestroyInstance(ctx, session.ProviderID); err != nil {
+		m.logger.Error("fire-and-forget destroy failed",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID),
+			slog.String("error", err.Error()))
+	} else {
+		m.logger.Info("fire-and-forget destroy succeeded",
+			slog.String("session_id", session.ID),
+			slog.String("provider_id", session.ProviderID))
+	}
 }
 
 // destroySession destroys a single session using the provider

--- a/internal/service/lifecycle/startup_test.go
+++ b/internal/service/lifecycle/startup_test.go
@@ -347,3 +347,62 @@ func TestStartupShutdownManager_GetMetrics(t *testing.T) {
 	assert.Equal(t, int64(0), metrics.SessionsDestroyed)
 	assert.Equal(t, int64(0), metrics.DestroyFailures)
 }
+
+func TestGracefulShutdown_FireAndForgetOnTimeout(t *testing.T) {
+	// Slow provider takes 1s to destroy — longer than the 200ms shutdown timeout,
+	// but short enough to complete within the fire-and-forget 10s timeout.
+	slowProv := &mockStartupProvider{
+		name:         "slow-provider",
+		destroyDelay: 1 * time.Second,
+	}
+	// Fast provider destroys immediately
+	fastProv := &mockStartupProvider{
+		name: "fast-provider",
+	}
+
+	store := &mockStartupStore{
+		sessions: []*models.Session{
+			{
+				ID:         "fast-session",
+				Provider:   "fast-provider",
+				ProviderID: "fast-instance",
+				Status:     models.StatusRunning,
+			},
+			{
+				ID:         "slow-session",
+				Provider:   "slow-provider",
+				ProviderID: "slow-instance",
+				Status:     models.StatusRunning,
+			},
+		},
+	}
+
+	registry := newMockProviderRegistry()
+	registry.providers["fast-provider"] = fastProv
+	registry.providers["slow-provider"] = slowProv
+	reconciler := NewReconciler(nil, nil)
+
+	// Very short shutdown timeout to trigger fire-and-forget path
+	manager := NewStartupShutdownManager(
+		store,
+		reconciler,
+		registry,
+		WithShutdownTimeout(200*time.Millisecond),
+	)
+
+	ctx := context.Background()
+	err := manager.GracefulShutdown(ctx)
+
+	// Should return an error because slow session wasn't destroyed in time
+	assert.Error(t, err)
+
+	// Fast provider should have been destroyed normally (exactly 1 call)
+	assert.Equal(t, 1, fastProv.getDestroyCalls())
+
+	// Slow provider should have received at least one destroy call —
+	// the fire-and-forget attempt after timeout. Wait for the fire-and-forget
+	// goroutine to complete (1s delay + margin).
+	time.Sleep(2 * time.Second)
+	assert.GreaterOrEqual(t, slowProv.getDestroyCalls(), 1,
+		"slow provider should have received at least one destroy call (fire-and-forget)")
+}

--- a/internal/service/provisioner/service.go
+++ b/internal/service/provisioner/service.go
@@ -68,6 +68,9 @@ const (
 
 	// BlueLobsterBootDelay waits for post-boot dist-upgrade SSH instability.
 	BlueLobsterBootDelay = 60 * time.Second
+
+	// DefaultLowBalanceThreshold is the balance below which a warning is logged
+	DefaultLowBalanceThreshold = 5.00
 )
 
 // ProgressiveBackoff implements an exponential backoff strategy with a maximum cap.
@@ -189,6 +192,9 @@ type Service struct {
 	destroyTimeout time.Duration
 	destroyRetries int
 	sshKeyBits     int
+
+	// Balance warning
+	lowBalanceThreshold float64
 
 	// For time mocking in tests
 	now func() time.Time
@@ -318,6 +324,7 @@ func New(store SessionStore, providers ProviderRegistry, opts ...Option) *Servic
 		destroyTimeout:       DefaultDestroyTimeout,
 		destroyRetries:       DefaultDestroyRetries,
 		sshKeyBits:           DefaultSSHKeyBits,
+		lowBalanceThreshold: DefaultLowBalanceThreshold,
 		now:                  time.Now,
 		destroyLocks:         make(map[string]*sync.Mutex),
 	}
@@ -368,6 +375,25 @@ func (s *Service) createSessionWithRetry(ctx context.Context, req models.CreateS
 		slog.String("offer_id", req.OfferID),
 		slog.String("provider", offer.Provider),
 		slog.Int("retry_count", retryCount))
+
+	// Check provider balance (warn-only)
+	if prov, err := s.providers.Get(offer.Provider); err == nil {
+		if bp, ok := prov.(provider.BalanceProvider); ok {
+			if balance, err := bp.GetAccountBalance(ctx); err == nil {
+				if balance.Balance < s.lowBalanceThreshold {
+					s.logger.Warn("LOW BALANCE: provider account balance is below threshold",
+						slog.String("provider", offer.Provider),
+						slog.Float64("balance", balance.Balance),
+						slog.Float64("threshold", s.lowBalanceThreshold),
+						slog.String("currency", balance.Currency))
+				}
+			} else {
+				s.logger.Debug("could not check provider balance",
+					slog.String("provider", offer.Provider),
+					slog.String("error", err.Error()))
+			}
+		}
+	}
 
 	// Check for existing active session for this consumer and offer
 	// Skip this check for retry attempts (the consumer already has a failed session for a different offer)

--- a/internal/service/provisioner/service.go
+++ b/internal/service/provisioner/service.go
@@ -324,7 +324,7 @@ func New(store SessionStore, providers ProviderRegistry, opts ...Option) *Servic
 		destroyTimeout:       DefaultDestroyTimeout,
 		destroyRetries:       DefaultDestroyRetries,
 		sshKeyBits:           DefaultSSHKeyBits,
-		lowBalanceThreshold: DefaultLowBalanceThreshold,
+		lowBalanceThreshold:  DefaultLowBalanceThreshold,
 		now:                  time.Now,
 		destroyLocks:         make(map[string]*sync.Mutex),
 	}

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -223,6 +223,10 @@ func (s *SessionStore) ListInternal(ctx context.Context, filter SessionFilter) (
 		args = append(args, filter.ExpiresBeforeTime)
 	}
 
+	if filter.HasProviderID {
+		query += " AND provider_instance_id != ''"
+	}
+
 	query += " ORDER BY created_at DESC"
 
 	if filter.Limit > 0 {
@@ -283,6 +287,15 @@ func (s *SessionStore) GetExpiredSessions(ctx context.Context) ([]*models.Sessio
 	})
 }
 
+// GetFailedSessionsWithInstances returns failed sessions that still have a provider instance ID.
+// These are sessions where destruction may have failed, leaving a provider instance potentially running.
+func (s *SessionStore) GetFailedSessionsWithInstances(ctx context.Context) ([]*models.Session, error) {
+	return s.ListInternal(ctx, SessionFilter{
+		Statuses:      []models.SessionStatus{models.StatusFailed},
+		HasProviderID: true,
+	})
+}
+
 // GetSessionsByStatus returns sessions with specific statuses
 func (s *SessionStore) GetSessionsByStatus(ctx context.Context, statuses ...models.SessionStatus) ([]*models.Session, error) {
 	return s.ListInternal(ctx, SessionFilter{
@@ -308,6 +321,7 @@ type SessionFilter struct {
 	Status            models.SessionStatus
 	Statuses          []models.SessionStatus
 	ExpiresBeforeTime time.Time
+	HasProviderID     bool
 	Limit             int
 }
 

--- a/internal/storage/sessions_test.go
+++ b/internal/storage/sessions_test.go
@@ -595,6 +595,94 @@ func TestSessionStore_CountSessionsByProviderAndStatus(t *testing.T) {
 	assert.Equal(t, 0, countMap["vastai:failed"])
 }
 
+func TestSessionStore_GetFailedSessionsWithInstances(t *testing.T) {
+	db := newTestDB(t)
+	store := NewSessionStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+
+	// Case 1: Failed session WITH provider ID — should be returned
+	failedWithProvider := &models.Session{
+		ID:             "sess-failed-with-provider",
+		ConsumerID:     "consumer-001",
+		Provider:       "vastai",
+		ProviderID:     "provider-instance-999",
+		OfferID:        "offer-1",
+		GPUType:        "RTX4090",
+		GPUCount:       1,
+		Status:         models.StatusFailed,
+		Error:          "destroy failed: connection timeout",
+		WorkloadType:   "ml-training",
+		ReservationHrs: 4,
+		StoragePolicy:  "destroy",
+		PricePerHour:   0.50,
+		CreatedAt:      now.Add(-time.Hour),
+		ExpiresAt:      now,
+	}
+	err := store.Create(ctx, failedWithProvider)
+	require.NoError(t, err)
+
+	// Case 2: Failed session WITHOUT provider ID — should NOT be returned
+	failedWithoutProvider := &models.Session{
+		ID:             "sess-failed-no-provider",
+		ConsumerID:     "consumer-001",
+		Provider:       "vastai",
+		OfferID:        "offer-2",
+		GPUType:        "RTX4090",
+		GPUCount:       1,
+		Status:         models.StatusFailed,
+		Error:          "provisioning failed: no capacity",
+		WorkloadType:   "ml-training",
+		ReservationHrs: 4,
+		StoragePolicy:  "destroy",
+		PricePerHour:   0.50,
+		CreatedAt:      now.Add(-time.Hour),
+		ExpiresAt:      now,
+	}
+	err = store.Create(ctx, failedWithoutProvider)
+	require.NoError(t, err)
+
+	// Case 3: Running session WITH provider ID — should NOT be returned (wrong status)
+	runningWithProvider := &models.Session{
+		ID:             "sess-running-with-provider",
+		ConsumerID:     "consumer-001",
+		Provider:       "vastai",
+		ProviderID:     "provider-instance-888",
+		OfferID:        "offer-3",
+		GPUType:        "RTX4090",
+		GPUCount:       1,
+		Status:         models.StatusRunning,
+		WorkloadType:   "ml-training",
+		ReservationHrs: 4,
+		StoragePolicy:  "destroy",
+		PricePerHour:   0.50,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(4 * time.Hour),
+	}
+	err = store.Create(ctx, runningWithProvider)
+	require.NoError(t, err)
+
+	// Query: should return only the failed session with a provider ID
+	results, err := store.GetFailedSessionsWithInstances(ctx)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "sess-failed-with-provider", results[0].ID)
+	assert.Equal(t, models.StatusFailed, results[0].Status)
+	assert.Equal(t, "provider-instance-999", results[0].ProviderID)
+}
+
+func TestSessionStore_GetFailedSessionsWithInstances_Empty(t *testing.T) {
+	db := newTestDB(t)
+	store := NewSessionStore(db)
+	ctx := context.Background()
+
+	// No sessions at all — should return empty slice, no error
+	results, err := store.GetFailedSessionsWithInstances(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
 func TestSessionStore_CountSessionsByProviderAndStatus_Empty(t *testing.T) {
 	db := newTestDB(t)
 	store := NewSessionStore(db)


### PR DESCRIPTION
## Summary

- **Failed-destroy watchdog**: Lifecycle manager periodically re-attempts destruction for sessions stuck in `failed` state with live provider instances (fixes the root cause where a failed destroy left GPU instances running indefinitely)
- **Shutdown fire-and-forget fallback**: When graceful shutdown times out, fires last-chance destroy calls with a fresh context for any sessions not yet confirmed destroyed. Default shutdown timeout increased from 60s to 120s
- **Startup sweep extension**: `RecoverStuckSessions` now also recovers failed sessions with provider IDs on server boot, destroying any still-running leaked instances
- **Reconcile interval reduced**: 5min → 2min for faster orphan detection
- **BalanceProvider interface**: New optional interface for checking provider account balance before provisioning. Vast.ai implementation using `/users/current/` endpoint. Logs WARNING when balance is below $5 threshold (warn-only, does not block)
- **TensorDock instance visibility**: Unknown instances (without `shopper-` prefix) now logged at WARN level during reconciliation

## Design doc

See `docs/plans/2026-02-23-termination-protections-design.md` for root cause analysis and design rationale.

## Test plan

- [x] New storage query `GetFailedSessionsWithInstances` with 2 tests
- [x] `checkFailedDestroys` lifecycle watchdog with 2 tests (success + failure paths)
- [x] Fire-and-forget shutdown fallback with 1 test (slow + fast providers)
- [x] Startup sweep for failed sessions with 4 tests (all branches)
- [x] TensorDock unknown instance logging with 1 test
- [x] Vast.ai `GetAccountBalance` with 2 tests (success + auth error)
- [x] Full test suite passes (`go test ./...`, `go vet`, `gofmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)